### PR TITLE
Move filesystems under a group/space, use resourcegroupstaggingapi 

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ POST `/v1/efs/{account}/filesystems/{group}`
         },
         {
             "Key": "spinup:spaceid",
-            "Value": "somegroup"
+            "Value": "spindev-00001"
         },
         {
             "Key": "Bill.Me",
@@ -124,10 +124,10 @@ GET `/v1/efs/{account}/filesystems`
 
 ```json
 [
-    "fs-1234567",
-    "fs-7654321",
-    "fs-9876543",
-    "fs-abcdefg"
+    "spindev-00001/fs-1234567",
+    "spindev-00001/fs-7654321",
+    "spindev-00002/fs-9876543",
+    "spindev-00003/fs-abcdefg"
 ]
 ```
 
@@ -209,7 +209,7 @@ GET `/v1/efs/{account}/filesystems/{group}/{id}`
         },
         {
             "Key": "spinup:spaceid",
-            "Value": "somegroup"
+            "Value": "spindev-00001"
         },
         {
             "Key": "Bill.Me",

--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ GET /v1/efs/version
 GET /v1/efs/metrics
 
 GET    /v1/efs/{account}/filesystems
-POST   /v1/efs/{account}/filesystems
-GET    /v1/efs/{account}/filesystems/{id}
-DELETE /v1/efs/{account}/filesystems/{id}
+GET    /v1/efs/{account}/filesystems/{group}
+POST   /v1/efs/{account}/filesystems/{group}
+GET    /v1/efs/{account}/filesystems/{group}/{id}
+DELETE /v1/efs/{account}/filesystems/{group}/{id}
 ```
 
 ## Authentication
@@ -26,7 +27,7 @@ Authentication is accomplished via a pre-shared key.  This is done via the `X-Au
 Creating a filesystem generates an EFS filesystem, and mount targets in all of the configured subnets
 with the passed security groups.  If no security groups are passed, the default will be used.
 
-POST `/v1/efs/{account}/filesystems`
+POST `/v1/efs/{account}/filesystems/{group}`
 
 | Response Code                 | Definition                      |
 | ----------------------------- | --------------------------------|
@@ -97,6 +98,10 @@ POST `/v1/efs/{account}/filesystems`
             "Value": "spindev"
         },
         {
+            "Key": "spinup:spaceid",
+            "Value": "somegroup"
+        },
+        {
             "Key": "Bill.Me",
             "Value": "Later"
         }
@@ -104,7 +109,7 @@ POST `/v1/efs/{account}/filesystems`
 }
 ```
 
-### List FileSystems by id
+### List FileSystems
 
 GET `/v1/efs/{account}/filesystems`
 
@@ -121,13 +126,34 @@ GET `/v1/efs/{account}/filesystems`
 [
     "fs-1234567",
     "fs-7654321",
-    "fs-9876543"
+    "fs-9876543",
+    "fs-abcdefg"
+]
+```
+
+### List FileSystems by group id
+
+GET `/v1/efs/{account}/filesystems/{group}`
+
+| Response Code                 | Definition                      |
+| ----------------------------- | --------------------------------|
+| **200 OK**                    | return the list of filesystems  |
+| **400 Bad Request**           | badly formed request            |
+| **404 Not Found**             | account not found               |
+| **500 Internal Server Error** | a server error occurred         |
+
+#### Example list by group response
+
+```json
+[
+    "fs-9876543",
+    "fs-abcdefg"
 ]
 ```
 
 ### Get details about a FileSystem, including it's mount targets and access points
 
-GET `/v1/efs/{account}/filesystems/{id}`
+GET `/v1/efs/{account}/filesystems/{group}/{id}`
 
 | Response Code                 | Definition                      |
 | ----------------------------- | --------------------------------|
@@ -182,6 +208,10 @@ GET `/v1/efs/{account}/filesystems/{id}`
             "Value": "spindev"
         },
         {
+            "Key": "spinup:spaceid",
+            "Value": "somegroup"
+        },
+        {
             "Key": "Bill.Me",
             "Value": "Later"
         }
@@ -191,7 +221,7 @@ GET `/v1/efs/{account}/filesystems/{id}`
 
 ### Delete a FileSystem and all associated mount targets and access points
 
-DELETE `/v1/efs/{account}/filesystems/{id}`
+DELETE `/v1/efs/{account}/filesystems/{group}/{id}`
 
 | Response Code                 | Definition                               |
 | ----------------------------- | -----------------------------------------|

--- a/api/routes.go
+++ b/api/routes.go
@@ -29,8 +29,10 @@ func (s *server) routes() {
 	api.HandleFunc("/version", s.VersionHandler).Methods(http.MethodGet)
 	api.Handle("/metrics", promhttp.Handler()).Methods(http.MethodGet)
 
+	// TODO move to "/{account}/filesystems/{group}/{id}" ?
 	api.HandleFunc("/{account}/filesystems", s.FileSystemListHandler).Methods(http.MethodGet)
-	api.HandleFunc("/{account}/filesystems", s.FileSystemCreateHandler).Methods(http.MethodPost)
-	api.HandleFunc("/{account}/filesystems/{id}", s.FileSystemShowHandler).Methods(http.MethodGet)
-	api.HandleFunc("/{account}/filesystems/{id}", s.FileSystemDeleteHandler).Methods(http.MethodDelete)
+	api.HandleFunc("/{account}/filesystems/{group}", s.FileSystemListHandler).Methods(http.MethodGet)
+	api.HandleFunc("/{account}/filesystems/{group}", s.FileSystemCreateHandler).Methods(http.MethodPost)
+	api.HandleFunc("/{account}/filesystems/{group}/{id}", s.FileSystemShowHandler).Methods(http.MethodGet)
+	api.HandleFunc("/{account}/filesystems/{group}/{id}", s.FileSystemDeleteHandler).Methods(http.MethodDelete)
 }

--- a/api/routes.go
+++ b/api/routes.go
@@ -29,7 +29,6 @@ func (s *server) routes() {
 	api.HandleFunc("/version", s.VersionHandler).Methods(http.MethodGet)
 	api.Handle("/metrics", promhttp.Handler()).Methods(http.MethodGet)
 
-	// TODO move to "/{account}/filesystems/{group}/{id}" ?
 	api.HandleFunc("/{account}/filesystems", s.FileSystemListHandler).Methods(http.MethodGet)
 	api.HandleFunc("/{account}/filesystems/{group}", s.FileSystemListHandler).Methods(http.MethodGet)
 	api.HandleFunc("/{account}/filesystems/{group}", s.FileSystemCreateHandler).Methods(http.MethodPost)

--- a/api/server.go
+++ b/api/server.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/YaleSpinup/efs-api/common"
 	"github.com/YaleSpinup/efs-api/efs"
+	"github.com/YaleSpinup/efs-api/resourcegroupstaggingapi"
 
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
@@ -39,11 +40,12 @@ func init() {
 }
 
 type server struct {
-	efsServices map[string]efs.EFS
-	router      *mux.Router
-	version     common.Version
-	context     context.Context
-	org         string
+	efsServices          map[string]efs.EFS
+	rgTaggingAPIServices map[string]resourcegroupstaggingapi.ResourceGroupsTaggingAPI
+	router               *mux.Router
+	version              common.Version
+	context              context.Context
+	org                  string
 }
 
 // NewServer creates a new server and starts it
@@ -57,17 +59,19 @@ func NewServer(config common.Config) error {
 	}
 
 	s := server{
-		efsServices: make(map[string]efs.EFS),
-		router:      mux.NewRouter(),
-		version:     config.Version,
-		context:     ctx,
-		org:         config.Org,
+		efsServices:          make(map[string]efs.EFS),
+		rgTaggingAPIServices: make(map[string]resourcegroupstaggingapi.ResourceGroupsTaggingAPI),
+		router:               mux.NewRouter(),
+		version:              config.Version,
+		context:              ctx,
+		org:                  config.Org,
 	}
 
 	// Create shared sessions
 	for name, c := range config.Accounts {
 		log.Infof("Creating new efs-api service for account '%s' with key '%s' in region '%s' (org: %s)", name, c.Akid, c.Region, s.org)
 		s.efsServices[name] = efs.NewSession(c)
+		s.rgTaggingAPIServices[name] = resourcegroupstaggingapi.NewSession(c)
 	}
 
 	publicURLs := map[string]string{

--- a/api/types.go
+++ b/api/types.go
@@ -229,8 +229,8 @@ func fileSystemResponseFromEFS(fs *efs.FileSystemDescription, mts []*efs.MountTa
 	return &filesystem
 }
 
-// normalizTags strips the org and spaceid from the given tags and ensures they
-// are set to the API org and the group string passed to the request
+// normalizTags strips the org, spaceid and name from the given tags and ensures they
+// are set to the API org and the group string, name passed to the request
 func (s *server) normalizeTags(name, group string, tags []*Tag) []*Tag {
 	normalizedTags := []*Tag{}
 	for _, t := range tags {
@@ -281,7 +281,7 @@ func toEFSTags(tags []*Tag) []*efs.Tag {
 	return efsTags
 }
 
-// litFileSystems returns a list of elasticfilesystems with the given org tag and the group/spaceid tag
+// listFileSystems returns a list of elasticfilesystems with the given org tag and the group/spaceid tag
 func (s *server) listFileSystems(ctx context.Context, account, group string) ([]string, error) {
 	rgtService, ok := s.rgTaggingAPIServices[account]
 	if !ok {
@@ -337,7 +337,7 @@ func (s *server) listFileSystems(ctx context.Context, account, group string) ([]
 
 // fileSystemExists checks if a filesystem exists in a group/space by getting a list of all filesystems
 // tagged with the spaceid and checking against that list. alternatively, we could get the filesystem from
-// the API and check if it has the right tag, but this seems more dangerous and less repeatable.  in other
+// the API and check if it has the right tag, but that seems more dangerous and less repeatable.  in other
 // words, this process might be slower but is hopefully safer.
 func (s *server) fileSystemExists(ctx context.Context, account, group, fs string) (bool, error) {
 	log.Debugf("checking if filesystem %s is in the group %s", fs, group)

--- a/api/types.go
+++ b/api/types.go
@@ -1,9 +1,14 @@
 package api
 
 import (
+	"context"
+	"strings"
 	"time"
 
+	"github.com/YaleSpinup/apierror"
+	"github.com/YaleSpinup/efs-api/resourcegroupstaggingapi"
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/service/efs"
 	log "github.com/sirupsen/logrus"
@@ -224,6 +229,34 @@ func fileSystemResponseFromEFS(fs *efs.FileSystemDescription, mts []*efs.MountTa
 	return &filesystem
 }
 
+// normalizTags strips the org and spaceid from the given tags and ensures they
+// are set to the API org and the group string passed to the request
+func (s *server) normalizeTags(name, group string, tags []*Tag) []*Tag {
+	normalizedTags := []*Tag{}
+	for _, t := range tags {
+		if t.Key == "spinup:spaceid" || t.Key == "spinup:org" || t.Key == "Name" {
+			continue
+		}
+		normalizedTags = append(normalizedTags, t)
+	}
+
+	normalizedTags = append(normalizedTags,
+		&Tag{
+			Key:   "Name",
+			Value: name,
+		},
+		&Tag{
+			Key:   "spinup:org",
+			Value: s.org,
+		}, &Tag{
+			Key:   "spinup:spaceid",
+			Value: group,
+		})
+
+	log.Debugf("returning normalized tags: %+v", normalizedTags)
+	return normalizedTags
+}
+
 // fromEFSTags converts from EFS tags to api Tags
 func fromEFSTags(efsTags []*efs.Tag) []*Tag {
 	tags := make([]*Tag, 0, len(efsTags))
@@ -246,4 +279,88 @@ func toEFSTags(tags []*Tag) []*efs.Tag {
 		})
 	}
 	return efsTags
+}
+
+// litFileSystems returns a list of elasticfilesystems with the given org tag and the group/spaceid tag
+func (s *server) listFileSystems(ctx context.Context, account, group string) ([]string, error) {
+	rgtService, ok := s.rgTaggingAPIServices[account]
+	if !ok {
+		return nil, apierror.New(apierror.ErrNotFound, "account not found", nil)
+	}
+
+	// build up tag filters starting with the org
+	tagFilters := []*resourcegroupstaggingapi.TagFilter{
+		{
+			Key:   "spinup:org",
+			Value: []string{s.org},
+		},
+	}
+
+	// if a group was passed, append a filter for the space id
+	if group != "" {
+		tagFilters = append(tagFilters, &resourcegroupstaggingapi.TagFilter{
+			Key:   "spinup:spaceid",
+			Value: []string{group},
+		})
+	}
+
+	// get a list of elastic filesystems matching the tag filters
+	out, err := rgtService.GetResourcesWithTags(ctx, []string{"elasticfilesystem"}, tagFilters)
+	if err != nil {
+		return nil, err
+	}
+
+	fsList := make([]string, 0, len(out))
+	for _, fs := range out {
+		a, err := arn.Parse(aws.StringValue(fs.ResourceARN))
+		if err != nil {
+			log.Errorf("failed to parse ARN %s: %s", fs, err)
+			fsList = append(fsList, aws.StringValue(fs.ResourceARN))
+		}
+
+		fsid := strings.TrimPrefix(a.Resource, "file-system/")
+		if group == "" {
+			for _, t := range fs.Tags {
+				if aws.StringValue(t.Key) == "spinup:spaceid" {
+					fsid = aws.StringValue(t.Value) + "/" + fsid
+				}
+			}
+		}
+
+		fsList = append(fsList, fsid)
+	}
+
+	log.Debugf("returning list of filesystems in group %s: %+v", group, fsList)
+
+	return fsList, nil
+}
+
+// fileSystemExists checks if a filesystem exists in a group/space by getting a list of all filesystems
+// tagged with the spaceid and checking against that list. alternatively, we could get the filesystem from
+// the API and check if it has the right tag, but this seems more dangerous and less repeatable.  in other
+// words, this process might be slower but is hopefully safer.
+func (s *server) fileSystemExists(ctx context.Context, account, group, fs string) (bool, error) {
+	log.Debugf("checking if filesystem %s is in the group %s", fs, group)
+
+	list, err := s.listFileSystems(ctx, account, group)
+	if err != nil {
+		return false, err
+	}
+
+	for _, f := range list {
+		id := f
+		if arn.IsARN(f) {
+			if a, err := arn.Parse(f); err != nil {
+				log.Errorf("failed to parse ARN %s: %s", f, err)
+			} else {
+				id = strings.TrimPrefix(a.Resource, "file-system/")
+			}
+		}
+
+		if id == fs {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }

--- a/api/types_test.go
+++ b/api/types_test.go
@@ -1,0 +1,127 @@
+package api
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
+	"github.com/aws/aws-sdk-go/service/efs"
+)
+
+func TestFileSystemResponseFromEFS(t *testing.T) {
+	t.Log("TODO")
+}
+
+func TestNormalizeTags(t *testing.T) {
+	s := server{
+		org: "testOrg",
+	}
+
+	type testTags struct {
+		name   string
+		group  string
+		tags   []*Tag
+		expect []*Tag
+	}
+
+	tests := []*testTags{
+		{
+			name:  "",
+			group: "",
+			tags:  nil,
+			expect: []*Tag{
+				{Key: "Name", Value: ""},
+				{Key: "spinup:org", Value: "testOrg"},
+				{Key: "spinup:spaceid", Value: ""},
+			},
+		},
+		{
+			name:  "SomeFS",
+			group: "MySpace",
+			tags:  nil,
+			expect: []*Tag{
+				{Key: "Name", Value: "SomeFS"},
+				{Key: "spinup:org", Value: "testOrg"},
+				{Key: "spinup:spaceid", Value: "MySpace"},
+			},
+		},
+		{
+			name:  "SomeFS1",
+			group: "MySpace",
+			tags: []*Tag{
+				{Key: "Name", Value: "SomeOtherFSName"},
+				{Key: "spinup:org", Value: "SomeOtherOrgName"},
+				{Key: "spinup:spaceid", Value: "SomeOtherSpaceID"},
+			},
+			expect: []*Tag{
+				{Key: "Name", Value: "SomeFS1"},
+				{Key: "spinup:org", Value: "testOrg"},
+				{Key: "spinup:spaceid", Value: "MySpace"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		out := s.normalizeTags(test.name, test.group, test.tags)
+		if !reflect.DeepEqual(test.expect, out) {
+			t.Errorf("expected %+v, got %+v", awsutil.Prettify(test.expect), awsutil.Prettify(out))
+		}
+	}
+}
+
+func TestFromEFSTags(t *testing.T) {
+	input := []*efs.Tag{}
+	expected := []*Tag{}
+	if output := fromEFSTags(input); !reflect.DeepEqual(expected, output) {
+		t.Errorf("expected %+v, got %+v for input %+v", expected, output, input)
+	}
+
+	input = []*efs.Tag{
+		{
+			Key:   aws.String("foo"),
+			Value: aws.String("bar"),
+		},
+	}
+	expected = []*Tag{
+		{
+			Key:   "foo",
+			Value: "bar",
+		},
+	}
+	if output := fromEFSTags(input); !reflect.DeepEqual(expected, output) {
+		t.Errorf("expected %+v, got %+v for input %+v", expected, output, input)
+	}
+}
+
+func TestToEFSTags(t *testing.T) {
+	input := []*Tag{}
+	expected := []*efs.Tag{}
+	if output := toEFSTags(input); !reflect.DeepEqual(expected, output) {
+		t.Errorf("expected %+v, got %+v for input %+v", expected, output, input)
+	}
+
+	input = []*Tag{
+		{
+			Key:   "foo",
+			Value: "bar",
+		},
+	}
+	expected = []*efs.Tag{
+		{
+			Key:   aws.String("foo"),
+			Value: aws.String("bar"),
+		},
+	}
+	if output := toEFSTags(input); !reflect.DeepEqual(expected, output) {
+		t.Errorf("expected %+v, got %+v for input %+v", expected, output, input)
+	}
+}
+
+func TestListFileSystems(t *testing.T) {
+	t.Log("TODO")
+}
+
+func TestFileSystemExists(t *testing.T) {
+	t.Log("TODO")
+}

--- a/resourcegroupstaggingapi/errors.go
+++ b/resourcegroupstaggingapi/errors.go
@@ -1,0 +1,97 @@
+package resourcegroupstaggingapi
+
+import (
+	"github.com/YaleSpinup/apierror"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
+	"github.com/pkg/errors"
+)
+
+func ErrCode(msg string, err error) error {
+	if aerr, ok := errors.Cause(err).(awserr.Error); ok {
+		switch aerr.Code() {
+		case
+
+			// ErrCodeInternalServiceException for service response error code
+			// "InternalServiceException".
+			//
+			// The request processing failed because of an unknown error, exception, or
+			// failure. You can retry the request.
+			resourcegroupstaggingapi.ErrCodeInternalServiceException:
+
+			return apierror.New(apierror.ErrInternalError, msg, err)
+		case
+
+			// ErrCodeConcurrentModificationException for service response error code
+			// "ConcurrentModificationException".
+			//
+			// The target of the operation is currently being modified by a different request.
+			// Try again later.
+			resourcegroupstaggingapi.ErrCodeConcurrentModificationException,
+
+			// ErrCodeThrottledException for service response error code
+			// "ThrottledException".
+			//
+			// The request was denied to limit the frequency of submitted requests.
+			resourcegroupstaggingapi.ErrCodeThrottledException:
+			return apierror.New(apierror.ErrConflict, msg, aerr)
+		case
+
+			// ErrCodeConstraintViolationException for service response error code
+			// "ConstraintViolationException".
+			//
+			// The request was denied because performing this operation violates a constraint.
+			//
+			// Some of the reasons in the following list might not apply to this specific
+			// operation.
+			//
+			//    * You must meet the prerequisites for using tag policies. For information,
+			//    see Prerequisites and Permissions for Using Tag Policies (http://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_tag-policies-prereqs.html)
+			//    in the AWS Organizations User Guide.
+			//
+			//    * You must enable the tag policies service principal (tagpolicies.tag.amazonaws.com)
+			//    to integrate with AWS Organizations For information, see EnableAWSServiceAccess
+			//    (http://docs.aws.amazon.com/organizations/latest/APIReference/API_EnableAWSServiceAccess.html).
+			//
+			//    * You must have a tag policy attached to the organization root, an OU,
+			//    or an account.
+			resourcegroupstaggingapi.ErrCodeConstraintViolationException,
+
+			// ErrCodeInvalidParameterException for service response error code
+			// "InvalidParameterException".
+			//
+			// This error indicates one of the following:
+			//
+			//    * A parameter is missing.
+			//
+			//    * A malformed string was supplied for the request parameter.
+			//
+			//    * An out-of-range value was supplied for the request parameter.
+			//
+			//    * The target ID is invalid, unsupported, or doesn't exist.
+			//
+			//    * You can't access the Amazon S3 bucket for report storage. For more information,
+			//    see Additional Requirements for Organization-wide Tag Compliance Reports
+			//    (http://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_tag-policies-prereqs.html#bucket-policies-org-report)
+			//    in the AWS Organizations User Guide.
+			resourcegroupstaggingapi.ErrCodeInvalidParameterException,
+
+			// ErrCodePaginationTokenExpiredException for service response error code
+			// "PaginationTokenExpiredException".
+			//
+			// A PaginationToken is valid for a maximum of 15 minutes. Your request was
+			// denied because the specified PaginationToken has expired.
+			resourcegroupstaggingapi.ErrCodePaginationTokenExpiredException:
+
+			return apierror.New(apierror.ErrBadRequest, msg, aerr)
+		case
+			"Not Found":
+			return apierror.New(apierror.ErrNotFound, msg, aerr)
+		default:
+			m := msg + ": " + aerr.Message()
+			return apierror.New(apierror.ErrBadRequest, m, aerr)
+		}
+	}
+
+	return apierror.New(apierror.ErrInternalError, msg, err)
+}

--- a/resourcegroupstaggingapi/errors_test.go
+++ b/resourcegroupstaggingapi/errors_test.go
@@ -1,0 +1,38 @@
+package resourcegroupstaggingapi
+
+import (
+	"testing"
+
+	"github.com/YaleSpinup/apierror"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
+	"github.com/pkg/errors"
+)
+
+func TestErrCode(t *testing.T) {
+	apiErrorTestCases := map[string]string{
+		"": apierror.ErrBadRequest,
+		resourcegroupstaggingapi.ErrCodeInternalServiceException:        apierror.ErrInternalError,
+		resourcegroupstaggingapi.ErrCodeConcurrentModificationException: apierror.ErrConflict,
+		resourcegroupstaggingapi.ErrCodeThrottledException:              apierror.ErrConflict,
+		resourcegroupstaggingapi.ErrCodeConstraintViolationException:    apierror.ErrBadRequest,
+		resourcegroupstaggingapi.ErrCodeInvalidParameterException:       apierror.ErrBadRequest,
+		resourcegroupstaggingapi.ErrCodePaginationTokenExpiredException: apierror.ErrBadRequest,
+	}
+
+	for awsErr, apiErr := range apiErrorTestCases {
+		err := ErrCode("test error", awserr.New(awsErr, awsErr, nil))
+		if aerr, ok := errors.Cause(err).(apierror.Error); ok {
+			t.Logf("got apierror '%s'", aerr)
+		} else {
+			t.Errorf("expected resourcegroupstaggingapi error %s to be an apierror.Error %s, got %s", awsErr, apiErr, err)
+		}
+	}
+
+	err := ErrCode("test error", errors.New("Unknown"))
+	if aerr, ok := errors.Cause(err).(apierror.Error); ok {
+		t.Logf("got apierror '%s'", aerr)
+	} else {
+		t.Errorf("expected unknown error to be an apierror.ErrInternalError, got %s", err)
+	}
+}

--- a/resourcegroupstaggingapi/resourcegroupstaggingapi.go
+++ b/resourcegroupstaggingapi/resourcegroupstaggingapi.go
@@ -1,0 +1,69 @@
+package resourcegroupstaggingapi
+
+import (
+	"context"
+	"strings"
+
+	"github.com/YaleSpinup/apierror"
+	"github.com/YaleSpinup/efs-api/common"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
+	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi/resourcegroupstaggingapiiface"
+	log "github.com/sirupsen/logrus"
+)
+
+// ResourceGroupsTaggingAPI is a wrapper around the aws resourcegroupstaggingapi service with some default config info
+type ResourceGroupsTaggingAPI struct {
+	Service resourcegroupstaggingapiiface.ResourceGroupsTaggingAPIAPI
+}
+
+// Tag Filter is used to filter resources based on tags.  The Value portion is optional.
+type TagFilter struct {
+	Key   string
+	Value []string
+}
+
+// NewSession creates a new cloudfront session
+func NewSession(account common.Account) ResourceGroupsTaggingAPI {
+	s := ResourceGroupsTaggingAPI{}
+	log.Infof("creating new aws session for resourcegroupstaggingapi with key id %s in region %s", account.Akid, account.Region)
+	sess := session.Must(session.NewSession(&aws.Config{
+		Credentials: credentials.NewStaticCredentials(account.Akid, account.Secret, ""),
+		Region:      aws.String(account.Region),
+	}))
+	s.Service = resourcegroupstaggingapi.New(sess)
+	return s
+}
+
+// GetResourcesWithTags returns all of the resources with a type in the list of types that matches the tagfilters.  More
+// details about which services support the resourgroup tagging api is here https://docs.aws.amazon.com/ARG/latest/userguide/supported-resources.html
+func (r *ResourceGroupsTaggingAPI) GetResourcesWithTags(ctx context.Context, types []string, filters []*TagFilter) ([]*resourcegroupstaggingapi.ResourceTagMapping, error) {
+	if len(filters) == 0 {
+		return nil, apierror.New(apierror.ErrBadRequest, "invalid input", nil)
+	}
+
+	log.Infof("getting resources with type '%s' that match tags", strings.Join(types, ", "))
+
+	tagFilters := make([]*resourcegroupstaggingapi.TagFilter, 0, len(filters))
+	for _, f := range filters {
+		log.Debugf("tagfilter: %s:%+v", f.Key, f.Value)
+		tagFilters = append(tagFilters, &resourcegroupstaggingapi.TagFilter{
+			Key:    aws.String(f.Key),
+			Values: aws.StringSlice(f.Value),
+		})
+	}
+
+	out, err := r.Service.GetResourcesWithContext(ctx, &resourcegroupstaggingapi.GetResourcesInput{
+		ResourceTypeFilters: aws.StringSlice(types),
+		TagFilters:          tagFilters,
+	})
+	if err != nil {
+		return nil, ErrCode("getting resource with tags", err)
+	}
+
+	log.Debugf("got output from get resources: %+v", out)
+
+	return out.ResourceTagMappingList, nil
+}

--- a/resourcegroupstaggingapi/resourcegroupstaggingapi_test.go
+++ b/resourcegroupstaggingapi/resourcegroupstaggingapi_test.go
@@ -1,0 +1,199 @@
+package resourcegroupstaggingapi
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/YaleSpinup/efs-api/common"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
+	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi/resourcegroupstaggingapiiface"
+)
+
+// mockResourceGroupsTaggingAPIClient is a fake resourcegroupstaggingapi client
+type mockResourceGroupsTaggingAPIClient struct {
+	resourcegroupstaggingapiiface.ResourceGroupsTaggingAPIAPI
+	t   *testing.T
+	err error
+}
+
+func newmockResourceGroupsTaggingAPIClient(t *testing.T, err error) resourcegroupstaggingapiiface.ResourceGroupsTaggingAPIAPI {
+	return &mockResourceGroupsTaggingAPIClient{
+		t:   t,
+		err: err,
+	}
+}
+
+func TestNewSession(t *testing.T) {
+	e := NewSession(common.Account{})
+	to := reflect.TypeOf(e).String()
+	if to != "resourcegroupstaggingapi.ResourceGroupsTaggingAPI" {
+		t.Errorf("expected type to be 'resourcegroupstaggingapi.ResourceGroupsTaggingAPI', got %s", to)
+	}
+}
+
+type tag struct {
+	key   string
+	value string
+}
+
+type testResource struct {
+	resourceType string
+	tags         []tag
+	arn          string
+}
+
+var testResources = []testResource{
+	{
+		resourceType: "ec2:instance",
+		tags: []tag{
+			{
+				key:   "spinup:org",
+				value: "foobar",
+			},
+			{
+				key:   "spinup:spaceid",
+				value: "123",
+			},
+		},
+		arn: "arn:aws:ec2:us-east-1:1234567890:instance/i-0987654321",
+	},
+	{
+		resourceType: "elasticloadbalancing:targetgroup",
+		tags: []tag{
+			{
+				key:   "spinup:org",
+				value: "foobar",
+			},
+			{
+				key:   "spinup:spaceid",
+				value: "123",
+			},
+		},
+		arn: "arn:aws:elasticloadbalancing:us-east-1:1234567890:targetgroup/testtg123/0987654321",
+	},
+	{
+		resourceType: "elasticloadbalancing:targetgroup",
+		tags: []tag{
+			{
+				key:   "spinup:org",
+				value: "foobar",
+			},
+			{
+				key:   "spinup:spaceid",
+				value: "321",
+			},
+		},
+		arn: "arn:aws:elasticloadbalancing:us-east-1:1234567890:targetgroup/testtg321/0987654321",
+	},
+}
+
+func (m *mockResourceGroupsTaggingAPIClient) GetResourcesWithContext(ctx context.Context, input *resourcegroupstaggingapi.GetResourcesInput, opts ...request.Option) (*resourcegroupstaggingapi.GetResourcesOutput, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+
+	resourceList := []*resourcegroupstaggingapi.ResourceTagMapping{}
+	for _, r := range testResources {
+		if len(input.ResourceTypeFilters) > 0 {
+			var typeMatch bool
+			for _, t := range input.ResourceTypeFilters {
+				if aws.StringValue(t) == r.resourceType {
+					typeMatch = true
+					break
+				}
+			}
+
+			if !typeMatch {
+				continue
+			}
+		}
+
+		matches := true
+		for _, filter := range input.TagFilters {
+			innerMatch := func() bool {
+				m.t.Logf("processing tagfilter %+v", filter)
+				for _, rt := range r.tags {
+					if aws.StringValue(filter.Key) == rt.key {
+						m.t.Logf("tag keys match for %s (%s = %s)", r.arn, rt.key, aws.StringValue(filter.Key))
+						if len(filter.Values) == 0 {
+							m.t.Logf("appending %s to the list, keys match (%s = %s) and no value specified", r.arn, rt.key, aws.StringValue(filter.Key))
+							return true
+						}
+
+						for _, value := range aws.StringValueSlice(filter.Values) {
+							if value == rt.value {
+								m.t.Logf("appending %s to the list, keys match (%s = %s) and value matches (%s = %s)", r.arn, rt.key, aws.StringValue(filter.Key), value, rt.value)
+								return true
+							}
+						}
+					}
+				}
+				m.t.Logf("returning false for %s", r.arn)
+				return false
+			}()
+
+			if !innerMatch {
+				matches = false
+			}
+		}
+
+		if matches {
+			m.t.Logf("resource %s matches", r.arn)
+			resourceList = append(resourceList, &resourcegroupstaggingapi.ResourceTagMapping{
+				ResourceARN: aws.String(r.arn),
+			})
+		}
+	}
+
+	return &resourcegroupstaggingapi.GetResourcesOutput{
+		ResourceTagMappingList: resourceList,
+	}, nil
+}
+
+func TestGetResourcesWithTags(t *testing.T) {
+	r := ResourceGroupsTaggingAPI{Service: newmockResourceGroupsTaggingAPIClient(t, nil)}
+	filters := []*TagFilter{
+		{
+			Key:   "spinup:org",
+			Value: []string{"foobar"},
+		},
+		{
+			Key:   "spinup:spaceid",
+			Value: []string{"123"},
+		},
+	}
+	out, err := r.GetResourcesWithTags(context.TODO(), []string{"elasticloadbalancing:targetgroup"}, filters)
+	if err != nil {
+		t.Errorf("expected nil error, got %s", err)
+	}
+
+	expected := []*resourcegroupstaggingapi.ResourceTagMapping{
+		{
+			ResourceARN: aws.String("arn:aws:elasticloadbalancing:us-east-1:1234567890:targetgroup/testtg123/0987654321"),
+		},
+	}
+
+	if !reflect.DeepEqual(expected, out) {
+		t.Errorf("expected %+v, got %+v", expected, out)
+	}
+
+	out, err = r.GetResourcesWithTags(context.TODO(), []string{}, filters)
+	if err != nil {
+		t.Errorf("expected nil error, got %s", err)
+	}
+
+	expected = []*resourcegroupstaggingapi.ResourceTagMapping{
+		{
+			ResourceARN: aws.String("arn:aws:ec2:us-east-1:1234567890:instance/i-0987654321"),
+		},
+		{
+			ResourceARN: aws.String("arn:aws:elasticloadbalancing:us-east-1:1234567890:targetgroup/testtg123/0987654321"),
+		},
+	}
+	if !reflect.DeepEqual(expected, out) {
+		t.Errorf("expected %+v, got %+v", expected, out)
+	}
+}


### PR DESCRIPTION
* Move all of the filesystem routes under a `{group}` which maps to the spaceid
* List filesystems by group
* Use the resourcegrouptaggingapi to determine if a filesystem belongs to a group before showing/deleting
* Enforce tagging convensions