### PR TITLE
Add support for passing filesystem lifecycle configuration on create

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ POST `/v1/efs/{account}/filesystems/{group}`
 {
     "Name": "myAwesomeFilesystem",
     "KmsKeyId": "arn:aws:kms:us-east-1:1234567890:key/0000000-1111-1111-1111-33333333333",
+    "LifeCycleConfiguration": "NONE | AFTER_7_DAYS | AFTER_14_DAYS | AFTER_30_DAYS | AFTER_60_DAYS | AFTER_90_DAYS",
     "Sgs": ["sg-abc123456789"],
     "Tags": [
         {
@@ -67,6 +68,7 @@ POST `/v1/efs/{account}/filesystems/{group}`
     "FileSystemId": "fs-9876543",
     "KmsKeyId": "arn:aws:kms:us-east-1:1234567890:key/0000000-1111-1111-1111-33333333333",
     "LifeCycleState": "creating",
+    "LifeCycleConfiguration": "NONE | AFTER_7_DAYS | AFTER_14_DAYS | AFTER_30_DAYS | AFTER_60_DAYS | AFTER_90_DAYS",
     "MountTargets": [
         {
             "AvailabilityZoneId": "use1-az2",
@@ -177,6 +179,7 @@ GET `/v1/efs/{account}/filesystems/{group}/{id}`
     "FileSystemId": "fs-9876543",
     "KmsKeyId": "arn:aws:kms:us-east-1:1234567890:key/0000000-1111-1111-1111-33333333333",
     "LifeCycleState": "available",
+    "LifeCycleConfiguration": "NONE | AFTER_7_DAYS | AFTER_14_DAYS | AFTER_30_DAYS | AFTER_60_DAYS | AFTER_90_DAYS",
     "MountTargets": [
         {
             "AvailabilityZoneId": "use1-az2",

--- a/api/handlers_filesystems.go
+++ b/api/handlers_filesystems.go
@@ -111,7 +111,13 @@ func (s *server) FileSystemShowHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	output := fileSystemResponseFromEFS(filesystem, mounttargets, nil)
+	lifecycle, err := efsService.GetFilesystemLifecycle(r.Context(), aws.StringValue(filesystem.FileSystemId))
+	if err != nil {
+		handleError(w, err)
+		return
+	}
+
+	output := fileSystemResponseFromEFS(filesystem, mounttargets, nil, lifecycle)
 	j, err := json.Marshal(output)
 	if err != nil {
 		log.Errorf("cannot marshal response (%v) into JSON: %s", output, err)


### PR DESCRIPTION
> 	// Valid values: NONE | AFTER_7_DAYS | AFTER_14_DAYS | AFTER_30_DAYS | AFTER_60_DAYS | AFTER_90_DAYS