### PR TITLE
prepare account, add user to access group, users to orchestration pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,15 @@ This API provides simple restful API access to EFS services.
       - [Example get accesspoint response](#example-get-accesspoint-response)
     - [Delete an accesspoint](#delete-an-accesspoint)
       - [Example delete accesspoint response](#example-delete-accesspoint-response)
+    - [Create a filesystem user](#create-a-filesystem-user)
+      - [Example create user request](#example-create-user-request)
+      - [Example create user response](#example-create-user-response)
+    - [List users for a filesystem](#list-users-for-a-filesystem)
+      - [Example list users response](#example-list-users-response)
+    - [Get details about a filesystem user](#get-details-about-a-filesystem-user)
+      - [Example get user response](#example-get-user-response)
+    - [Delete a filesystem user](#delete-a-filesystem-user)
+      - [Example get user response](#example-get-user-response-1)
     - [Get task information for asynchronous tasks](#get-task-information-for-asynchronous-tasks)
       - [Example task response](#example-task-response)
   - [License](#license)
@@ -306,7 +315,7 @@ DELETE `/v1/efs/{account}/filesystems/{group}/{id}`
 
 ### Create an accesspoint for a filesystem
 
-Creating an accesspoint generates an accesspoint for a filesystem.  The
+Creating an accesspoint generates an accesspoint for a filesystem.
 
 POST `/v1/efs/{account}/filesystems/{group}/{id}/aps`
 
@@ -403,6 +412,93 @@ DELETE `/v1/efs/{account}/filesystems/{group}/{id}/aps/{apid}`
 OK
 ```
 
+### Create a filesystem user
+
+Creates a user with full access to a filesystem
+
+POST `/v1/efs/{account}/filesystems/{group}/{id}/users`
+
+#### Example create user request
+
+```json
+{
+    "Username": "someuser"
+}
+```
+
+#### Example create user response
+
+```json
+{
+    "UserName": "someuser",
+    "Tags": []
+}
+```
+
+| Response Code                 | Definition              |
+| ----------------------------- | ------------------------|
+| **200 OK**                    | create a user           |
+| **400 Bad Request**           | badly formed request    |
+| **404 Not Found**             | account not found       |
+| **500 Internal Server Error** | a server error occurred |
+
+### List users for a filesystem
+
+GET ``/v1/efs/{account}/filesystems/{group}/{id}/users`
+
+#### Example list users response
+
+```json
+[
+    "someuser",
+    "someotheruser"
+]
+```
+
+| Response Code                 | Definition              |
+| ----------------------------- | ------------------------|
+| **200 OK**                    | list all users          |
+| **400 Bad Request**           | badly formed request    |
+| **404 Not Found**             | account not found       |
+| **500 Internal Server Error** | a server error occurred |
+
+### Get details about a filesystem user
+
+GET ``/v1/efs/{account}/filesystems/{group}/{id}/users/{username}`
+
+#### Example get user response
+
+```json
+{
+    "UserName": "someuser",
+    "Tags": []
+}
+```
+
+| Response Code                 | Definition              |
+| ----------------------------- | ------------------------|
+| **200 OK**                    | get a user              |
+| **400 Bad Request**           | badly formed request    |
+| **404 Not Found**             | account not found       |
+| **500 Internal Server Error** | a server error occurred |
+
+### Delete a filesystem user
+
+DELETE ``/v1/efs/{account}/filesystems/{group}/{id}/users/{username}`
+
+#### Example get user response
+
+```json
+OK
+```
+
+| Response Code                 | Definition              |
+| ----------------------------- | ------------------------|
+| **200 OK**                    | delete a user           |
+| **400 Bad Request**           | badly formed request    |
+| **404 Not Found**             | account not found       |
+| **500 Internal Server Error** | a server error occurred |
+
 ### Get task information for asynchronous tasks
 
 GET /v1/efs/flywheel?task=xxx[&task=yyy&task=zzz]
@@ -455,4 +551,4 @@ GET /v1/efs/flywheel?task=xxx[&task=yyy&task=zzz]
 ## License
 
 GNU Affero General Public License v3.0 (GNU AGPLv3)  
-Copyright © 2020 Yale University
+Copyright © 2021 Yale University

--- a/api/orchestration_account.go
+++ b/api/orchestration_account.go
@@ -1,0 +1,178 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+
+	"github.com/YaleSpinup/apierror"
+	"github.com/YaleSpinup/aws-go/services/iam"
+	"github.com/aws/aws-sdk-go/aws"
+	log "github.com/sirupsen/logrus"
+)
+
+var efsAdminPolicyDoc string
+var EfsAdminPolicy = iam.PolicyDocument{
+	Version: "2012-10-17",
+	Statement: []iam.StatementEntry{
+		{
+			Sid:    "AllowActionsOnVolumesInSpaceAndOrg",
+			Effect: "Allow",
+			Action: []string{
+				"elasticfilesystem:ClientRootAccess",
+				"elasticfilesystem:ClientWrite",
+				"elasticfilesystem:ClientMount",
+			},
+			Resource: []string{"*"},
+			Condition: iam.Condition{
+				"StringEqualsIgnoreCase": iam.ConditionStatement{
+					"aws:ResourceTag/Name":           []string{"${aws:PrincipalTag/ResourceName}"},
+					"aws:ResourceTag/spinup:org":     []string{"${aws:PrincipalTag/spinup:org}"},
+					"aws:ResourceTag/spinup:spaceid": []string{"${aws:PrincipalTag/spinup:spaceid}"},
+				},
+			},
+		},
+	},
+}
+
+// cachePolicyDoc generates the string value of the policy document the first time it's used and keeps
+// it in memory to prevent marshalling static data on each request.
+func cachePolicyDoc() error {
+	// initialize ecr admin policy document
+	policyDoc, err := json.Marshal(EfsAdminPolicy)
+	if err != nil {
+		return err
+	}
+	efsAdminPolicyDoc = string(policyDoc)
+	return nil
+}
+
+// prepareAccount sets up the account for user management by creating the admin policy and group
+func (o *userOrchestrator) prepareAccount(ctx context.Context) error {
+	log.Info("preparing account for user management")
+
+	path := fmt.Sprintf("/spinup/%s/", o.org)
+
+	if efsAdminPolicyDoc == "" {
+		if err := cachePolicyDoc(); err != nil {
+			return err
+		}
+	}
+
+	policyName := fmt.Sprintf("SpinupEFSAdminPolicy-%s", o.org)
+	policyArn, err := o.userCreatePolicyIfMissing(ctx, policyName, path)
+	if err != nil {
+		return err
+	}
+
+	groupName := fmt.Sprintf("SpinupEFSAdminGroup-%s", o.org)
+	if err := o.userCreateGroupIfMissing(ctx, groupName, path, policyArn); err != nil {
+		return err
+	}
+
+	return err
+}
+
+// userCreatePolicyIfMissing gets the given policy by name.  if the policy isn't found it simply creates the policy and
+// returns.  if the policy is found, it gets the policy document and compares to the expected policy document, updating
+// if they differ.
+func (o *userOrchestrator) userCreatePolicyIfMissing(ctx context.Context, name, path string) (string, error) {
+	log.Infof("creating policy %s in %s if missing", name, path)
+
+	policy, err := o.iamClient.GetPolicyByName(ctx, name, path)
+	if err != nil {
+		if aerr, ok := err.(apierror.Error); !ok || aerr.Code != apierror.ErrNotFound {
+			return "", err
+		}
+
+		log.Infof("policy %s not found, creating", name)
+	}
+
+	// if the policy isn't found, create it and return
+	if policy == nil {
+		out, err := o.iamClient.CreatePolicy(ctx, name, path, efsAdminPolicyDoc)
+		if err != nil {
+			return "", err
+		}
+
+		if err := o.iamClient.WaitForPolicy(ctx, aws.StringValue(out.Arn)); err != nil {
+			return "", err
+		}
+
+		return aws.StringValue(out.Arn), nil
+	}
+
+	out, err := o.iamClient.GetDefaultPolicyVersion(ctx, aws.StringValue(policy.Arn), aws.StringValue(policy.DefaultVersionId))
+	if err != nil {
+		return "", err
+	}
+
+	// Document is returned url encoded, we must decode it to unmarshal and compare
+	d, err := url.QueryUnescape(aws.StringValue(out.Document))
+	if err != nil {
+		return "", err
+	}
+
+	// If we cannot unmarshal the document we received into an iam.PolicyDocument or if
+	// the document doesn't match, let's try to update it.  If unmarshaling fails, we assume
+	// our struct has changed (for example going from Resource string to Resource []string)
+	var updatePolicy bool
+	doc := iam.PolicyDocument{}
+	if err := json.Unmarshal([]byte(d), &doc); err != nil {
+		log.Warnf("error getting policy document: %s, updating", err)
+		updatePolicy = true
+	} else if !iam.PolicyDeepEqual(doc, EfsAdminPolicy) {
+		log.Warn("policy document is not the same, updating")
+		updatePolicy = true
+	}
+
+	if updatePolicy {
+		if err := o.iamClient.UpdatePolicy(ctx, aws.StringValue(policy.Arn), efsAdminPolicyDoc); err != nil {
+			return "", err
+		}
+
+		// TODO: delete old version, only 5 versions allowed
+	}
+
+	return aws.StringValue(policy.Arn), nil
+}
+
+// userCreateGroupIfMissing gets the group and creates it if it's missing.  it also checks if the correct
+// policyArn is attached to the group, and attaches it if it's not.
+func (o *userOrchestrator) userCreateGroupIfMissing(ctx context.Context, name, path, policyArn string) error {
+	log.Infof("creating group %s in %s and assigning policy %s if missing", name, path, policyArn)
+
+	if _, err := o.iamClient.GetGroupWithPath(ctx, name, path); err != nil {
+		if aerr, ok := err.(apierror.Error); !ok || aerr.Code != apierror.ErrNotFound {
+			return err
+		}
+
+		log.Infof("group %s not found, creating", name)
+
+		if _, err := o.iamClient.CreateGroup(ctx, name, path); err != nil {
+			return err
+		}
+	}
+
+	// get the list of attached policies for the group
+	attachedPolicies, err := o.iamClient.ListAttachedGroupPolicies(ctx, name, path)
+	if err != nil {
+		return err
+	}
+
+	// return if the policy is already attached to the group
+	for _, p := range attachedPolicies {
+		if p != policyArn {
+			continue
+		}
+
+		return nil
+	}
+
+	if err := o.iamClient.AttachGroupPolicy(ctx, name, policyArn); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/api/orchestrators.go
+++ b/api/orchestrators.go
@@ -2,16 +2,19 @@ package api
 
 import (
 	"github.com/YaleSpinup/aws-go/services/iam"
+	"github.com/YaleSpinup/efs-api/efs"
 )
 
-type iamOrchestrator struct {
-	client iam.IAM
-	org    string
+type userOrchestrator struct {
+	iamClient iam.IAM
+	efsClient efs.EFS
+	org       string
 }
 
-func newIamOrchestrator(client iam.IAM, org string) *iamOrchestrator {
-	return &iamOrchestrator{
-		client: client,
-		org:    org,
+func newUserOrchestrator(iamClient iam.IAM, efsClient efs.EFS, org string) *userOrchestrator {
+	return &userOrchestrator{
+		iamClient: iamClient,
+		efsClient: efsClient,
+		org:       org,
 	}
 }

--- a/api/policy.go
+++ b/api/policy.go
@@ -96,11 +96,13 @@ func (s *server) filesystemUserDeletePolicy() (string, error) {
 					"iam:RemoveUserFromGroup",
 					"iam:ListAccessKeys",
 					"iam:ListGroupsForUser",
+					"iam:ListUsers",
 					"iam:DeleteUser",
 					"iam:GetUser",
 				},
 				Resource: []string{
 					fmt.Sprintf("arn:aws:iam::*:user/spinup/%s/*", s.org),
+					fmt.Sprintf("arn:aws:iam::*:group/spinup/%s/*", s.org),
 				},
 			},
 		},

--- a/api/policy_test.go
+++ b/api/policy_test.go
@@ -86,7 +86,7 @@ func Test_server_filesystemUserDeletePolicy(t *testing.T) {
 			fields: fields{
 				org: "testOrg",
 			},
-			want: `{"Version":"2012-10-17","Statement":[{"Sid":"DeleteRepositoryUser","Effect":"Allow","Action":["iam:DeleteAccessKey","iam:RemoveUserFromGroup","iam:ListAccessKeys","iam:ListGroupsForUser","iam:DeleteUser","iam:GetUser"],"Resource":["arn:aws:iam::*:user/spinup/testOrg/*"]}]}`,
+			want: `{"Version":"2012-10-17","Statement":[{"Sid":"DeleteRepositoryUser","Effect":"Allow","Action":["iam:DeleteAccessKey","iam:RemoveUserFromGroup","iam:ListAccessKeys","iam:ListGroupsForUser","iam:ListUsers","iam:DeleteUser","iam:GetUser"],"Resource":["arn:aws:iam::*:user/spinup/testOrg/*","arn:aws:iam::*:group/spinup/testOrg/*"]}]}`,
 		},
 	}
 	for _, tt := range tests {

--- a/api/types.go
+++ b/api/types.go
@@ -226,7 +226,6 @@ type AccessPoint struct {
 // FileSystemUserCreateRequest is the request payload for creating a filsystem user
 type FileSystemUserCreateRequest struct {
 	UserName string
-	// Groups   []string
 }
 
 // FileSystemUserResponse is the response payload for user operations


### PR DESCRIPTION
* prepare account with IAM access policy and IAM group using ABAC
* when creating users, attach them to the ABAC group
* tag users with ResourceName as part of the ABAC controls
* transition user management to use the orchestrator patter we use in other APIs, this leaves a few turds in the filesystem orchestration that will be cleaned up when we move those to the same pattern.

This PR does not:
- manage access keys for users
- assign the resource (efs) policy to force auth on an FS